### PR TITLE
Add fullnameOverride value to fully control resource naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 0.5.5 (2020-04-07)
+
+* (New) `fullnameOverride` string to override generated resource names prefix
+
 ## 0.5.4 (2020-04-05)
 
 * (New) `enablePrometheus` Boolean to bind Prometheus `/metrics` url to imgproxy

--- a/Readme.md
+++ b/Readme.md
@@ -215,3 +215,10 @@ Options to configure ServiceMonitor for Prometheus Operator.
 |**serviceMonitor.targetLabels**|Transfers mentioned labels on the Kubernetes Service onto the target|`["app","release"]`|
 
 See `values.yaml` for some more Kubernetes-specific configuration options.
+
+### Other
+
+|Value|Description|Default|
+|-----|-----------|-------|
+|**nameOverride**|String to partially override imgproxy.fullname template with a string (will be appended to the release name)|`nil`|
+|**fullnameOverride**|String to fully override imgproxy.fullname template with a string (will be used as pod name prefix instead of release name)|`nil`|

--- a/imgproxy/Chart.yaml
+++ b/imgproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A fast and secure standalone server for resizing and converting remote images. The main principles of imgproxy are simplicity, speed, and security.
 name: imgproxy
 icon: https://cdn.rawgit.com/imgproxy/imgproxy/master/logo.svg
-version: 0.5.4
+version: 0.5.5
 appVersion: 2.10.0
 keywords:
 - imgproxy

--- a/imgproxy/templates/_helpers.tpl
+++ b/imgproxy/templates/_helpers.tpl
@@ -12,7 +12,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "imgproxy.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- default (printf "%s-%s" .Release.Name $name) .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Sometimes you don't want to have release name as part of pod names.

Example usage:
```yaml
imgproxy:
  fullnameOverride: "imgproxy"
```

Resulted pod name: `imgproxy-5c6d97bddd-f4tfn`