### PR TITLE
Fix Ingress template annotations

### DIFF
--- a/imgproxy/templates/horizontalPodAutoscaler.yaml
+++ b/imgproxy/templates/horizontalPodAutoscaler.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "imgproxy.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "imgproxy.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.cpuAverageUtilization }}
+{{ end }}        

--- a/imgproxy/templates/ingress-health.yaml
+++ b/imgproxy/templates/ingress-health.yaml
@@ -11,7 +11,9 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.ingress.health.whitelist }}
 {{- if or .Values.ingress.annotations (and .Values.ingress.tls.enabled .Values.ingress.acme) }}
+{{ if .Values.ingress.annotations }}
 {{ toYaml .Values.ingress.annotations | indent 4 }}
+{{ end }}
 {{- if and .Values.ingress.tls.enabled .Values.ingress.acme }}
     kubernetes.io/tls-acme: "true"
 {{- end }}

--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -70,6 +70,12 @@ ingress:
     secretName: ""
   #   nginx.ingress.kubernetes.io/proxy-body-size: "32m"
 
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 10
+  cpuAverageUtilization: 50
+
 enablePrometheus: false
 serviceMonitor:
   enabled: false


### PR DESCRIPTION
Fixed ingress annotations so that `kubernetes.io/tls-acme: "true"` will appear even if `.Values.ingress.annotations` is empty.