### PR TITLE
Ability to add multiple hosts and deploy behing a global static IP

### DIFF
--- a/imgproxy/templates/ingress-health.yaml
+++ b/imgproxy/templates/ingress-health.yaml
@@ -14,7 +14,7 @@ metadata:
 {{ toYaml .Values.ingress.health.annotations | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.ingress.tls.enabled }}
+{{- if .Values.tls.enabled }}
   tls:
   - hosts:
     - {{ .Values.ingress.health.host }}

--- a/imgproxy/templates/ingress-health.yaml
+++ b/imgproxy/templates/ingress-health.yaml
@@ -10,18 +10,18 @@ metadata:
     heritage: "{{ .Release.Service }}"
   annotations:
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.ingress.health.whitelist }}
-{{- if .Values.ingress.annotations }}
-{{ toYaml .Values.ingress.annotations | indent 4 }}
+{{- if .Values.ingress.health.annotations }}
+{{ toYaml .Values.ingress.health.annotations | indent 4 }}
 {{- end }}
 spec:
 {{- if .Values.ingress.tls.enabled }}
   tls:
   - hosts:
-    - {{ .Values.ingress.host }}
+    - {{ .Values.ingress.health.host }}
     secretName: {{ .Values.ingress.tls.secretName | default (printf "%s-tls" (include "imgproxy.fullname" .)) | quote }}
 {{- end }}
   rules:
-  - host: {{ .Values.ingress.host }}
+  - host: {{ .Values.ingress.health.host }}
     http:
       paths:
       - path: /health

--- a/imgproxy/templates/ingress.yaml
+++ b/imgproxy/templates/ingress.yaml
@@ -9,21 +9,25 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-{{- if or .Values.ingress.annotations (and .Values.ingress.tls.enabled .Values.ingress.acme) }}
+{{- if or .Values.ingress.annotations (and .Values.tls.enabled .Values.ingress.acme) }}
   annotations:
 {{- if .Values.ingress.annotations }}
 {{ toYaml .Values.ingress.annotations | indent 4 }}
 {{- end }}
-{{- if and .Values.ingress.tls.enabled .Values.ingress.acme }}
+{{- if and .Values.tls.enabled .Values.ingress.acme }}
     kubernetes.io/tls-acme: "true"
 {{- end }}
 {{- end }}
 spec:
-{{- if .Values.ingress.tls.enabled }}
+{{- if .Values.tls.enabled }}
   tls:
+  {{- range $index, $tls := .Values.ingress.tls}}
   - hosts:
-    - {{ .Values.ingress.host }}
-    secretName: {{ .Values.ingress.tls.secretName | default (printf "%s-tls" (include "imgproxy.fullname" .)) | quote }}
+    {{- range $tls.hosts }}
+    - {{ . }}
+    {{- end}}
+    secretName: {{ $tls.secretName | default (printf "%s-tls-%d" (include "imgproxy.fullname" $dot) $index) | quote }}
+  {{- end}}
 {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}

--- a/imgproxy/templates/ingress.yaml
+++ b/imgproxy/templates/ingress.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.ingress.enabled -}}
+{{- $dot := . }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -25,11 +26,15 @@ spec:
     secretName: {{ .Values.ingress.tls.secretName | default (printf "%s-tls" (include "imgproxy.fullname" .)) | quote }}
 {{- end }}
   rules:
-  - host: {{ .Values.ingress.host }}
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: {{ template "imgproxy.fullname" . }}
-          servicePort: 80
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ template "imgproxy.fullname" $dot }}
+              servicePort: {{ $.Values.servicePort }}
+        {{- end }}
+  {{- end }}
 {{- end -}}

--- a/imgproxy/templates/ingress.yaml
+++ b/imgproxy/templates/ingress.yaml
@@ -34,7 +34,7 @@ spec:
           - path: {{ . }}
             backend:
               serviceName: {{ template "imgproxy.fullname" $dot }}
-              servicePort: {{ $.Values.servicePort }}
+              servicePort: 80
         {{- end }}
   {{- end }}
 {{- end -}}

--- a/imgproxy/templates/tls.secrets.yaml
+++ b/imgproxy/templates/tls.secrets.yaml
@@ -1,20 +1,27 @@
-{{- if and .Values.ingress.enabled .Values.ingress.tls.enabled }}
+{{- if and .Values.ingress.enabled .Values.tls.enabled }}
 {{- if not .Values.ingress.acme }}
-{{- if and .Values.ingress.tls.crt .Values.ingress.tls.key }}
+{{- $chartName := .Chart.Name -}}
+{{- $chartVersion := .Chart.Version -}}
+{{- $releaseName :=  .Release.Name -}}
+{{- $releaseService := .Release.Service -}}
+{{- $dot := . }}
+{{- range $index, $tls := .Values.ingress.tls}}
+{{- if and $tls.crt $tls.key }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.ingress.tls.secretName | default (printf "%s-tls" (include "imgproxy.fullname" .)) | quote }}
+  name: {{ $tls.secretName | default (printf "%s-tls-%d" (include "imgproxy.fullname" $dot) $index) | quote}}
   labels:
-    app: {{ template "imgproxy.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: {{ template "imgproxy.fullname" $dot }}
+    chart: "{{ $chartName }}-{{ $chartVersion }}"
+    release: "{{ $releaseName }}"
+    heritage: "{{ $releaseService }}"
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ .Values.ingress.tls.crt | b64enc }}
-  tls.key: {{ .Values.ingress.tls.key | b64enc }}
+  tls.crt: {{ $tls.crt | b64enc }}
+  tls.key: {{ $tls.key | b64enc }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -56,10 +56,15 @@ ingress:
   annotations: {}
   enabled: false
   health:
+    host: "example.com"
     # Comma separated string of CIDR addresses that are allowed
     # to access `/health` url of imgproxy.
     whitelist: ""
-  host: "example.com"
+    annotations: {}
+  hosts:
+    - host: "example.com"
+      paths:
+        - /
   tls:
     enabled: false
     crt: ""

--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -50,6 +50,9 @@ livenessProbe:
   successThreshold: 1
   failureThreshold: 5
 
+tls:
+  enabled: false
+
 # Configuration parameters for Ingress resource
 ingress:
   acme: false
@@ -65,12 +68,12 @@ ingress:
     - host: "example.com"
       paths:
         - /
-  tls:
-    enabled: false
-    crt: ""
-    key: ""
-    secretName: ""
-  #   nginx.ingress.kubernetes.io/proxy-body-size: "32m"
+  tls: []
+  #  - secretName: example-tls
+  #    crt: ""
+  #    key: ""
+  #    hosts:
+  #      - example.com
 
 enablePrometheus: false
 serviceMonitor:


### PR DESCRIPTION
The pull request aims to address two issues.

1) It adds the ability to set up multiple ingress hosts to address issue #8. 

2) For cloud providers that natively handles ingress, such as GKE, it allows the use of native ingress controllers with a global static IP address through the use of annotations as follows:

![ingress 2](https://user-images.githubusercontent.com/46919661/84195597-1fe75e00-aa9f-11ea-8640-8aae8dd45082.png)


The ability to deploy imgproxy behind a global static IP address while using cloud-native ingress controllers is achieved by doing the following:
a) Adding the ability to configure the paths for each ingress host.
b) Requiring the annotations of the ingress and health ingress to be set independently. Two ingresses cannot share the same static IP address which is implied by using the same annotations.

It addresses issue #9.

I have not updated the README file. I'd be happy to do it after any discussions.
