### PR TITLE
Add deployment annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.5.10 (2020-11-13)
 
+* (New) imgproxy `v2.15.0`
 * (New) `prometheusNamespace` to prepend prefix to the names of metrics
 * (New) add deployment annotations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 0.5.3 (2020-03-03)
+
+* (Fix) indentation typo in ingress-health.yaml
+
 ## 0.5.2 (2020-03-02)
 
 * (New) `ingress.health.whitelist` Comma separated string of CIDR addresses that are allowed to access `/health` url of imgproxy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
+## 0.5.10 (2020-11-13)
+
 * (New) `prometheusNamespace` to prepend prefix to the names of metrics
+* (New) add deployment annotations
 
 ## 0.5.9 (2020-06-10)
 

--- a/imgproxy/Chart.yaml
+++ b/imgproxy/Chart.yaml
@@ -3,7 +3,7 @@ description: A fast and secure standalone server for resizing and converting rem
 name: imgproxy
 icon: https://cdn.rawgit.com/imgproxy/imgproxy/master/logo.svg
 version: 0.5.10
-appVersion: 2.13.1
+appVersion: 2.15.0
 keywords:
 - imgproxy
 - image

--- a/imgproxy/Chart.yaml
+++ b/imgproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A fast and secure standalone server for resizing and converting remote images. The main principles of imgproxy are simplicity, speed, and security.
 name: imgproxy
 icon: https://cdn.rawgit.com/imgproxy/imgproxy/master/logo.svg
-version: 0.5.9
+version: 0.5.10
 appVersion: 2.13.1
 keywords:
 - imgproxy

--- a/imgproxy/Chart.yaml
+++ b/imgproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A fast and secure standalone server for resizing and converting remote images. The main principles of imgproxy are simplicity, speed, and security.
 name: imgproxy
 icon: https://cdn.rawgit.com/imgproxy/imgproxy/master/logo.svg
-version: 0.5.2
+version: 0.5.3
 appVersion: 2.10.0
 keywords:
 - imgproxy

--- a/imgproxy/templates/deployment.yaml
+++ b/imgproxy/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     app: {{ template "imgproxy.fullname" . }}
+  {{- if .Values.deployment.annotations }}
+  annotations:
+    {{ toYaml .Values.deployment.annotations | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/imgproxy/templates/ingress-health.yaml
+++ b/imgproxy/templates/ingress-health.yaml
@@ -8,8 +8,8 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-    annotations:
-      nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.ingress.health.whitelist }}
+  annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.ingress.health.whitelist }}
 {{- if or .Values.ingress.annotations (and .Values.ingress.tls.enabled .Values.ingress.acme) }}
 {{ toYaml .Values.ingress.annotations | indent 4 }}
 {{- if and .Values.ingress.tls.enabled .Values.ingress.acme }}

--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -14,7 +14,7 @@ tolerations: {}
 # Docker image repository, tag and a policy for Kubernetes to pull it.
 image:
   repo: darthsim/imgproxy
-  tag: v2.13.1
+  tag: v2.15.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: {}

--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -89,6 +89,10 @@ podDisruptionBudget:
 # Pod annotations
 annotations: {}
 
+# Deployment annotations
+deployment:
+  annotations: {}
+
 # Hex-encoded key for URL encoding. CHANGE IT!!!!
 key: 1b147116e57d9e06df3696b21260169902fe201ccdb9715267999176ccbfaae6f2c2b75b78110d0287643d98cde143e7a3f98a46ec825a1ab7ea10af426c2436
 


### PR DESCRIPTION
This pr adds new version of imgproxy and ability to set deployment annotations.

There are many use cases for this: for example, I want to use special annotations when configuring kube-downscaler rule.