### PR TITLE
Fix readinessProbe when using pathPrefix

### DIFF
--- a/imgproxy/templates/deployment.yaml
+++ b/imgproxy/templates/deployment.yaml
@@ -383,7 +383,7 @@ spec:
         {{- end }}
         readinessProbe:
           httpGet:
-            path: /health
+            path: {{ .Values.pathPrefix }}/health
             port: 8080
             scheme: HTTP
             httpHeaders:
@@ -397,7 +397,7 @@ spec:
           {{- end }}
         livenessProbe:
           httpGet:
-            path: /health
+            path: {{ .Values.pathPrefix }}/health
             port: 8080
             scheme: HTTP
             httpHeaders:


### PR DESCRIPTION
This should fix issue #13.

Unfortunately, when I tried installing the chart from the master branch (before making this change) the chart failed to install, so this change was tested for version 0.5.9.
