### PR TITLE
Add github action to create an issue about imgproxy changes

### DIFF
--- a/.github/templates/ISSUE.md
+++ b/.github/templates/ISSUE.md
@@ -1,0 +1,7 @@
+---
+title: Configuration of the imgproxy has been updated
+assignees: nepalez, dragonsmith
+labels: enhancement
+---
+@{{ payload.actor }} has just updated the [Configuration](https://docs.imgproxy.net/#/configuration) part of the documentation.
+Please, check [the difference]({{ payload.link }}) and make the necessary changes in the Helm chart.

--- a/.github/workflows/imgproxy-config-updated.yml
+++ b/.github/workflows/imgproxy-config-updated.yml
@@ -1,0 +1,25 @@
+#
+# This action is triggered by the repository_dispatch event
+# published by the imgproxy/imgproxy repository to imgproxy/imgproxy-helm.
+# It creates an issue and assign it to the gem's maintainers.
+#
+---
+name: Create an issue about updated imgproxy
+on:
+  repository_dispatch:
+    types:
+      - imgproxy-config-updated
+jobs:
+  create-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: JasonEtco/create-an-issue@v2
+        name: Create an issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/templates/ISSUE.md
+          assignees:
+            - nepalez
+            - dragonsmith


### PR DESCRIPTION
When the imgproxy sends the dispatch event 'imgproxy-updated' to this repository, the local action would publish an issue
and assign it to the gem's maintainers.

We should also add the corresponding action to the `imgproxy/imgproxy` with a write access to this one.

Checked the flow on my own repos and it works:
- [sender](https://github.com/nepalez/attestor/blob/master/.github/workflows/main.yml) (like `imgproxy/imgproxy`)
- [receiver](https://github.com/nepalez/sample_app/blob/master/.github/workflows/main.yml) (like `imgproxy/imgproxy-helm`)
- [the issue](https://github.com/nepalez/sample_app/issues/6)

---

Opened [another PR](https://github.com/imgproxy/imgproxy/pull/634) on the `imgproxy` side