### PR TITLE
Enable IMGPROXY_REPORT_DOWNLOADING_ERRORS to be set to false explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3 (2021-05-21)
+
+* (Fix) enable `IMGPROXY_REPORT_DOWNLOADING_ERRORS` to be set to `false` explicitly
+
 ## 0.6.2 (2021-05-20)
 
 * (New) Azure Blob Storage options (`useAbs`, `absName`, `absKey`, `absEndpoint`)

--- a/imgproxy/Chart.yaml
+++ b/imgproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A fast and secure standalone server for resizing and converting remote images. The main principles of imgproxy are simplicity, speed, and security.
 name: imgproxy
 icon: https://cdn.rawgit.com/imgproxy/imgproxy/master/logo.svg
-version: 0.6.2
+version: 0.6.3
 appVersion: 2.15.0
 keywords:
 - imgproxy

--- a/imgproxy/templates/deployment.yaml
+++ b/imgproxy/templates/deployment.yaml
@@ -334,11 +334,8 @@ spec:
         {{- end }}
         {{- end }}
 
-        {{- if .Values.reportDownloadingErrors }}
         - name: IMGPROXY_REPORT_DOWNLOADING_ERRORS
-          value: "true"
-        {{- end }}
-
+          value: {{ .Values.reportDownloadingErrors | ternary "true" "false" }}
         - name: IMGPROXY_LOG_FORMAT
           value: {{ .Values.logFormat | quote }}
         - name: IMGPROXY_LOG_LEVEL


### PR DESCRIPTION
Fixes https://github.com/imgproxy/imgproxy-helm/issues/28