### PR TITLE
Added Kubernetes service account

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -189,6 +189,9 @@ Deployment specific options.
 |**readinessProbe**|Timeouts and counters for the readiness probe||
 |**replicaCount**|How many pods with imgproxy should be running simultaneously|`1`|
 |**resources**|Hash of resource limits for your pods|`{}`|
+|**serviceAccount.enabled**|Enable or disable the creation of a Kubernetes service account for imgproxy|`false`|
+|**serviceAccount.name**|Name of the Kubernetes service account for imgproxy|`imgproxy`|
+|**serviceAccount.annotations**|Annotations for the Kubernetes service account for imgproxy|``|
 |**serviceType**|Kubernetes service type for imgproxy|`ClusterIP`|
 |**tolerations**|Tolerations for Kubernetes taints||
 

--- a/imgproxy/templates/deployment.yaml
+++ b/imgproxy/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
       imagePullSecrets:
       - name: "{{ .Release.Name }}-docker-registry-secret"
 {{- end }}
+{{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name | quote }} 
+{{- end }}
       containers:
       - name: "imgproxy"
         image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"

--- a/imgproxy/templates/serviceaccount.yaml
+++ b/imgproxy/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.enabled -}}
+{{- with .Values.serviceAccount -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .name | quote }}
+  annotations: {{ toYaml .annotations | nindent 4 }}
+{{- end -}}
+{{- end -}}

--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -22,6 +22,12 @@ imagePullSecrets: {}
   # username: ""
   # password: ""
 
+# Kubernetes service account details
+serviceAccount:
+  enabled: false
+  # name: ""
+  # annotations: {}
+
 # Kubernetes API version to use for imgproxy Deployment
 apiVersion: apps/v1
 


### PR DESCRIPTION
This PR enables the creation of a service account, useful to leverage eg. AWS IAM role binding (https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).