### PR TITLE
Fixed ingress.yaml for k8s 1.18

### DIFF
--- a/imgproxy/templates/ingress.yaml
+++ b/imgproxy/templates/ingress.yaml
@@ -1,9 +1,9 @@
 {{/* Current apiVersion of ingress */}}
 {{- $apiVersion := "extensions/v1beta1" }}
 {{- $apiVersions := $.Capabilities.APIVersions -}}
-{{- if $apiVersions.Has "networking.k8s.io/v1" -}}
+{{- if $apiVersions.Has "networking.k8s.io/v1/Ingress" -}}
 {{- $apiVersion = "networking.k8s.io/v1" -}}
-{{- else if $apiVersions.Has "networking.k8s.io/v1beta1" -}}
+{{- else if $apiVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
 {{- $apiVersion = "networking.k8s.io/v1beta1" -}}
 {{- end -}}
 


### PR DESCRIPTION
This ingress configuration wouldn't work for k8s 1.18, as it would match `networking.k8s.io/v1`.
But in 1.18, Ingress is not in `networking.k8s.io/v1`.
And it would throw this error:
```
Error: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "Ingress" in version "networking.k8s.io/v1"
```