### PR TITLE
Add checksum/env annotation to deployment

### DIFF
--- a/imgproxy/templates/deployment.yaml
+++ b/imgproxy/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       app: {{ template "imgproxy.fullname" $ }}
   template:
     metadata:
+      {{- $checksumEnv := include (print $.Template.BasePath "/env-secret.yaml") . | sha256sum -}}
       {{- with .Values.resources.pod }}
       labels:
         app: {{ template "imgproxy.fullname" $ }}
@@ -25,8 +26,9 @@ spec:
         {{- if .labels }}
         {{- .labels | toYaml | nindent 8 }}
         {{- end }}
-      {{- if .annotations }}
       annotations:
+        checksum/env: {{ $checksumEnv }}
+      {{- if .annotations }}
         {{- .annotations | toYaml | nindent 8 }}
       {{- end }}
       {{- end }}


### PR DESCRIPTION
If the config (secret env) changes, this forces k8s to redeploy the pod.

I've seen this trick in the (old) minio helm chart:
https://github.com/minio/charts/blob/master/minio/templates/deployment.yaml#L57-L58