### PR TITLE
Feature/autoscaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add checksum/env annotation to deployment to enable redeploy after changing secrets.
 * Support environment variables passed to the pods through custom secrets.
 * Support PVC for local files usage.
+* Support horizontal pod autoscaling based on average cpu utilization.
 
 ## 0.7.9 (2021-09-05)
 

--- a/imgproxy/templates/_helpers.tpl
+++ b/imgproxy/templates/_helpers.tpl
@@ -6,6 +6,10 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "imgproxy.chart" -}}
+{{- printf "%s-%s" $.Chart.Name ($.Chart.Version  | replace "+" "_") -}}
+{{- end -}}
+
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/imgproxy/templates/_versions.tpl
+++ b/imgproxy/templates/_versions.tpl
@@ -31,6 +31,20 @@
     {{- end -}}
 {{- end -}}
 
+{{/* API version of HorizontalPodAutoscaler. */}}
+{{- define "imgproxy.versions.horizontalPodAutoscaler" -}}
+    {{- $kubeVersion := $.Capabilities.KubeVersion.Version }}
+    {{- $apiVersions := $.Capabilities.APIVersions }}
+
+    {{- if $kubeVersion | semverCompare ">=1.19.0-0" -}}
+        {{- "autoscaling/v2beta2" -}}
+    {{- else if $kubeVersion | semverCompare ">=1.12.0-0" | and ($apiVersions.Has "autoscaling/v2beta2") -}}
+        {{- "autoscaling/v2beta2" -}}
+    {{- else if $apiVersions.Has "autoscaling/v2beta1" }}
+        {{- "autoscaling/v2beta1" -}}
+    {{- end -}}
+{{- end -}}
+
 {{/* Check if preemption policy is supported for PriorityClass. */}}
 {{- define "imgproxy.versions.features.priorityClassPreemptionPolicy" -}}
     {{- $.Capabilities.KubeVersion.Version | semverCompare ">= 1.19.0-0" }}

--- a/imgproxy/templates/deployment.yaml
+++ b/imgproxy/templates/deployment.yaml
@@ -13,7 +13,7 @@ metadata:
     app: {{ template "imgproxy.fullname" $ }}
   annotations: {{ .Values.resources.deployment.annotations | toYaml | nindent 4 }}
 spec:
-  replicas: {{ .Values.resources.deployment.replicaCount }}
+  replicas: {{ (.Values.resources.deployment.replicas | default dict).minCount | default 1 | int }}
   selector:
     matchLabels:
       app: {{ template "imgproxy.fullname" $ }}

--- a/imgproxy/templates/deployment.yaml
+++ b/imgproxy/templates/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    chart: {{ template "imgproxy.chart" $ }}
     app: {{ template "imgproxy.fullname" $ }}
   annotations: {{ .Values.resources.deployment.annotations | toYaml | nindent 4 }}
 spec:

--- a/imgproxy/templates/env-secret.yaml
+++ b/imgproxy/templates/env-secret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "imgproxy.fullname" $ }}-env-secrets
   labels:
     app: {{ template "imgproxy.fullname" $ }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "imgproxy.chart" $ }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     imgproxy: "true"

--- a/imgproxy/templates/horizontal-pod-autoscaler.yaml
+++ b/imgproxy/templates/horizontal-pod-autoscaler.yaml
@@ -1,0 +1,37 @@
+{{- $apiVersion := include "imgproxy.versions.horizontalPodAutoscaler" $ }}
+{{- with .Values.resources.deployment.replicas | default dict -}}
+{{- $minCount := .minCount | default 1 | int }}
+{{- $maxCount := .maxCount | default $minCount | int }}
+{{- if gt $maxCount $minCount -}}
+---
+apiVersion: {{ $apiVersion }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "imgproxy.fullname" $ }}-autoscaling
+  labels:
+    heritage: {{ $.Release.Service | quote }}
+    release: {{ $.Release.Name | quote }}
+    chart: {{ template "imgproxy.chart" $ }}
+    app: {{ template "imgproxy.fullname" $ }}
+spec:
+  minReplicas: {{ $minCount }}
+  maxReplicas: {{ $maxCount }}
+  scaleTargetRef:
+    kind: Deployment
+    name: {{ template "imgproxy.fullname" $ }}
+    apiVersion: apps/v1
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: {{ .stabilizationInterval | default 300 | max 0 | min 3600 }}
+    scaleUp:
+      stabilizationWindowSeconds: {{ .stabilizationInterval | default 300 | max 0 | min 3600 }}
+  metrics:
+    - type: ContainerResource
+    - containerResource:
+        container: imgproxy
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .cpuUtilization | default 0.8 }}
+{{- end }}
+{{- end }}

--- a/imgproxy/templates/image-pull-secret.yaml
+++ b/imgproxy/templates/image-pull-secret.yaml
@@ -6,7 +6,7 @@ kind: Secret
 metadata:
   labels:
     app: {{ template "imgproxy.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    chart: {{ template "imgproxy.chart" $ }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
     imgproxy: "true"

--- a/imgproxy/templates/ingress-health.yaml
+++ b/imgproxy/templates/ingress-health.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ template "imgproxy.fullname" $ }}-health
   labels:
     app: {{ template "imgproxy.fullname" $ }}
-    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    chart: {{ template "imgproxy.chart" $ }}
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
     imgproxy: "true"

--- a/imgproxy/templates/ingress.yaml
+++ b/imgproxy/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ template "imgproxy.fullname" $ }}
   labels:
     app: {{ template "imgproxy.fullname" $ }}
-    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    chart: {{ template "imgproxy.chart" $ }}
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
     imgproxy: "true"

--- a/imgproxy/templates/service.yaml
+++ b/imgproxy/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    chart: {{ template "imgproxy.chart" $ }}
     app: {{ .Release.Name | quote }}
     imgproxy: "true"
 {{- with .Values.resources.service }}

--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -36,7 +36,33 @@ resources:
     annotations: {}
 
     # How many instances of imgproxy you desire to spin up.
-    replicaCount: 1
+    # If `maxCount > minCount` then autoscaling is configured using
+    # the `stabilizationInterval` and `cpuUtilizationAverage` settings.
+    # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2beta2/#HorizontalPodAutoscalerSpec:
+    #
+    # This part can be skipped, in that case 1 replica will be used.
+    replicas:
+
+       # The minimum number of replicas (default 1).
+       minCount: 1
+
+       # The maximum number of replicas (default to `minCount`).
+       # Values less then `minCount` are ignored!
+       maxCount: 1
+
+       # The number of seconds for which past recommendations
+       # should be considered while scaling up or scaling down (0 - 3600).
+       # The period will be the same for both up- and downscaling.
+       #
+       # The setting is used if `minCount < maxCount` only (default 300).
+       stabilizationInterval: 300
+
+       # The average % of CPU utilization by imgproxy containers.
+       # The value is relative to the requested CPU utilization
+       # (resources.deployment.resources.requests.cpu).
+       #
+       # The setting MUST be set if `minCount < maxCount` only.
+       cpuUtilization: 0.8
 
     # A node selector label.
     nodeSelector: {}


### PR DESCRIPTION
Add support for horizontal pod autoscaling.
For now I supported only one metric, namely average CPU utilization by imgproxy container.

In the first commit I also extracted shared definition of the current chart to a template.