### PR TITLE
Add PVC and volumeMounts for deployment

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -344,6 +344,22 @@ Options to configure ServiceMonitor for Prometheus Operator.
 
 See `values.yaml` for some more Kubernetes-specific configuration options.
 
+### Persistence
+
+Options to mount a persistent volume.
+
+|Value|Description|Default|
+|-----|-----------|-------|
+|**persistence.enabled**|Enable persistence for deployment.|`false`|
+|**persistence.name**|Set name for persistent volume claim.|`imgproxy-data`|
+|**persistence.existingClaim**|Reference an existing PVC instead of creating a new one.|`""`|
+|**persistence.mountPath**|Mount path for PVC in the imgproxy pod.|`/images`|
+|**persistence.subPath**|Mount sub path of the persistent volume.|`""`|
+|**persistence.accessModes**|Access modes for the persistent volume.|`- ReadWriteOnce`|
+|**persistence.size**|Storage size of the PV.|`10Gi`|
+|**persistence.storageClass**|Set the storageClass for the persistent volume claim.|`""`|
+|**persistence.dataSource**|Create a PV from a data source (e.g. snapshot).|`""`|
+
 ### Other
 
 |Value|Description|Default|

--- a/imgproxy/templates/_helpers.tpl
+++ b/imgproxy/templates/_helpers.tpl
@@ -75,3 +75,12 @@ https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.ht
         {{- end }}
     {{- end }}
 {{- end -}}
+
+{{/* Return name for persistent volume claim */}}
+{{- define "imgproxy.pvcName" -}}
+{{- if .Values.persistence.existingClaim }}
+{{- print .Values.persistence.existingClaim }}
+{{- else -}}
+{{- print .Values.persistence.name }}
+{{- end -}}
+{{- end -}}

--- a/imgproxy/templates/_helpers.tpl
+++ b/imgproxy/templates/_helpers.tpl
@@ -78,9 +78,7 @@ https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.ht
 
 {{/* Return name for persistent volume claim */}}
 {{- define "imgproxy.pvcName" -}}
-{{- if .Values.persistence.existingClaim }}
-{{- print .Values.persistence.existingClaim }}
-{{- else -}}
-{{- print .Values.persistence.name }}
+{{- with $.Values.persistence -}}
+{{- .existingClaim | default .name | print }}
 {{- end -}}
 {{- end -}}

--- a/imgproxy/templates/deployment.yaml
+++ b/imgproxy/templates/deployment.yaml
@@ -42,6 +42,12 @@ spec:
       {{- if (include "serviceAccount.enabled" $) }}
       serviceAccountName: "{{ template "imgproxy.fullname" $ }}-service-account"
       {{- end }}
+      {{- if .Values.persistence.enabled }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "imgproxy.pvcName" . }}
+      {{- end }}
       containers:
         - name: "imgproxy"
           image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
@@ -51,6 +57,14 @@ spec:
                 name: {{ template "imgproxy.fullname" $ }}-env-secrets
           {{- if .Values.resources.deployment.resources }}
           resources: {{ .Values.resources.deployment.resources | toYaml | nindent 16 }}
+          {{- end }}
+          {{- if .Values.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+              {{- if .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}
+              {{- end }}
           {{- end }}
           ports:
             - containerPort: 8080

--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -120,6 +120,36 @@ resources:
     annotations: {}
     labels: {}
 
+# Configure persistence
+persistence:
+  # If persistence is enabled
+  enabled: false
+
+  # PVC name
+  name: "imgproxy-data"
+
+  # If existing claim should be used
+  existingClaim: ""
+
+  # Volume mount path in imgproxy deployment
+  mountPath: "/images"
+
+  # Persistent volume sub path
+  subPath: ""
+
+  # Access modes for PV
+  accessModes:
+    - ReadWriteOnce
+
+  # Storage size
+  size: 10Gi
+
+  # Storage Class for PVC
+  storageClass: ""
+
+  # Create new PV from data source
+  dataSource: ""
+
 # Configure imgproxy features
 # https://docs.imgproxy.net/#/configuration
 features:


### PR DESCRIPTION
This is a follow up on issue #2. The PR allows to serve files from localy attached volume (e.g. NFS shares or RWX).
The PR provides configurations for persistence. When enabled a PVC will be created. Also an existing PVC can be used instead. The PVC will get defined as a volume in the imgproxy deployment and the PV will be mounted at the specified mountPath.

It makes sense to configure IMGPROXY_LOCAL_FILESYSTEM_ROOT separately in the `values.yaml`:

```
features:
    security:
      allowedSources: "local://"
    custom:
      IMGPROXY_LOCAL_FILESYSTEM_ROOT: "/images"
```