### PR TITLE
feat(ingress): define ingress `path` explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.2 (2021-10-01)
+
+* Add `path` definition for ingress object to be able to not use `pathPrefix` environment variable.
+
 ## 0.8.1 (2021-09-29)
 
 * Add annotations for ArtifactHub.

--- a/Readme.md
+++ b/Readme.md
@@ -324,6 +324,7 @@ Deployment specific options.
 |**resources.ingress.enabled**|When true, enables ingress resource for imgproxy|`false`|
 |**resources.ingress.health.whitelist**|Comma separated string of CIDR addresses that are allowed to access `/health` url of imgproxy||
 |**resources.ingress.hosts**|Hostnames for the ingress resource to use|`["example.com"]`|
+|**resources.ingress.path**|Path to match the HTTP request|`/`|
 |**resources.ingress.tls**|TLS config array||
 |**resources.ingress.tls[].hosts**|Hostnames this tls secret is used for|`["example.com"]`|
 |**resources.ingress.tls[].secretName**|Name of the k8s Secret resource which stores crt & key for the ingress resource||

--- a/imgproxy/Chart.yaml
+++ b/imgproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A fast and secure standalone server for resizing and converting remote images. The main principles of imgproxy are simplicity, speed, and security.
 name: imgproxy
 icon: https://cdn.rawgit.com/imgproxy/imgproxy/master/logo.svg
-version: 0.8.1
+version: 0.8.2
 appVersion: 2.17.0
 keywords:
   - imgproxy

--- a/imgproxy/README.md
+++ b/imgproxy/README.md
@@ -324,6 +324,7 @@ Deployment specific options.
 |**resources.ingress.enabled**|When true, enables ingress resource for imgproxy|`false`|
 |**resources.ingress.health.whitelist**|Comma separated string of CIDR addresses that are allowed to access `/health` url of imgproxy||
 |**resources.ingress.hosts**|Hostnames for the ingress resource to use|`["example.com"]`|
+|**resources.ingress.path**|Path to match the HTTP request|`/`|
 |**resources.ingress.tls**|TLS config array||
 |**resources.ingress.tls[].hosts**|Hostnames this tls secret is used for|`["example.com"]`|
 |**resources.ingress.tls[].secretName**|Name of the k8s Secret resource which stores crt & key for the ingress resource||

--- a/imgproxy/templates/ingress-health.yaml
+++ b/imgproxy/templates/ingress-health.yaml
@@ -34,7 +34,7 @@ spec:
       http:
         paths:
           {{- $name := include "imgproxy.fullname" $ }}
-          {{- $path := ($.Values.features.server.pathPrefix | default "" | printf "%s/health") }}
+          {{- $path := ($.Values.resources.ingress.path | default "" | printf "%s/health") }}
           {{- if eq $apiVersion "networking.k8s.io/v1" }}
           - path: {{ $path | quote }}
             pathType: Exact

--- a/imgproxy/templates/ingress.yaml
+++ b/imgproxy/templates/ingress.yaml
@@ -33,7 +33,7 @@ spec:
       http:
         paths:
           {{- $name := include "imgproxy.fullname" $ }}
-          {{- $path := default "/" $.Values.features.server.pathPrefix }}
+          {{- $path := default "/" $.Values.resources.ingress.path }}
           {{- if eq $apiVersion "networking.k8s.io/v1" }}
           - path: {{ $path | quote }}
             pathType: ImplementationSpecific

--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -143,6 +143,7 @@ resources:
     hosts: []
     #   - example.com
     #   - www.example.com
+    path: "/"
     tls: []
     #   - secretName: example-com-tls
     #     hosts:


### PR DESCRIPTION
Define ingress `path` explicitly instead of using `pathPrefix`.

I want to have the choice to not use `pathPrefix` as the `path` in my ingress object.

Thanks a lot for your consideration.

Signed-off-by: Valentin Maillot <valentin.maillot@adfinis.com>