### PR TITLE
Add ability to use existing image pull secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.6 (2021-11-12)
+
+* Add ability to use existing image pull secrets
+
 ## 0.8.5 (2021-10-20)
 
 * Enforce default CPU resource settings

--- a/Readme.md
+++ b/Readme.md
@@ -293,6 +293,7 @@ Deployment specific options.
 |**image.pullSecrets.password**|Password to your private registry|``|
 |**image.pullSecrets.registry**|URL of a private registry you want to authorize to|``|
 |**image.pullSecrets.username**|Login to your private registry|``|
+|**image.addPullSecrets**|List of existing image pull secrets|`[]`|
 |**resources.deployment.affinity**|Node and inter-pod affinity configuration||
 |**resources.deployment.annotations**|Custom annotations for imgproxy deployment|`{}`|
 |**resources.pod.annotations**|Custom annotations for imgproxy pod|`{}`|

--- a/imgproxy/Chart.yaml
+++ b/imgproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A fast and secure standalone server for resizing and converting remote images. The main principles of imgproxy are simplicity, speed, and security.
 name: imgproxy
 icon: https://cdn.rawgit.com/imgproxy/imgproxy/master/logo.svg
-version: 0.8.5
+version: 0.8.6
 appVersion: 3.0.0.beta1
 keywords:
   - imgproxy

--- a/imgproxy/README.md
+++ b/imgproxy/README.md
@@ -341,6 +341,7 @@ Deployment specific options.
 |**image.pullSecrets.password**|Password to your private registry|``|
 |**image.pullSecrets.registry**|URL of a private registry you want to authorize to|``|
 |**image.pullSecrets.username**|Login to your private registry|``|
+|**image.addPullSecrets**|List of existing image pull secrets|`[]`|
 |**resources.deployment.affinity**|Node and inter-pod affinity configuration||
 |**resources.deployment.annotations**|Custom annotations for imgproxy deployment|`{}`|
 |**resources.pod.annotations**|Custom annotations for imgproxy pod|`{}`|

--- a/imgproxy/templates/deployment.yaml
+++ b/imgproxy/templates/deployment.yaml
@@ -38,9 +38,16 @@ spec:
       affinity: {{ .Values.resources.deployment.affinity | toYaml | nindent 8 }}
       tolerations: {{ .Values.resources.deployment.tolerations | toYaml | nindent 8 }}
       nodeSelector: {{ .Values.resources.deployment.nodeSelector | toYaml | nindent 8 }}
-      {{- if .Values.image.pullSecrets.enabled }}
+      {{- if or .Values.image.pullSecrets.enabled .Values.image.addPullSecrets }}
       imagePullSecrets:
+        {{- if .Values.image.pullSecrets.enabled}}
         - name: "{{ .Release.Name }}-docker-registry-secret"
+        {{- end }}
+        {{- if .Values.image.addPullSecrets}}
+        {{- range $secretName := .Values.image.addPullSecrets }}
+        - name: {{ $secretName | quote }}
+        {{- end }}
+        {{- end }}
       {{- end }}
       {{- if (include "serviceAccount.enabled" $) }}
       serviceAccountName: "{{ template "imgproxy.fullname" $ }}-service-account"

--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -4,11 +4,14 @@ image:
   repo: darthsim/imgproxy
   tag: v3.0.0.beta1
   pullPolicy: IfNotPresent
+  # create new image-pull-secret if enabled: true
   pullSecrets:
-    enabled:  false
+    enabled: false
     registry: ""
     username: ""
     password: ""
+  # list of existing image-pull-secrets
+  addPullSecrets: []
 
 # Configure K8s resources
 resources:


### PR DESCRIPTION
It is useful when you need no secret data in your `values.yaml`. For example, in the case of deployment with ArgoCD.