### PR TITLE
Fix deployment in presence of HPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.9 (to be released)
+
+* Fix deployment by removing `spec.replicas` in presence of HPA
+
 ## 0.8.8 (2021-11-23)
 
 * Support imgproxy v3.0.0.beta2

--- a/imgproxy/templates/deployment.yaml
+++ b/imgproxy/templates/deployment.yaml
@@ -1,7 +1,11 @@
 {{- $priorityClassName := include "imgproxy.resources.priorityClassName" . }}
 {{- $priorityClassVersion := include "imgproxy.versions.priorityClass" . }}
 {{- $checksumEnv := include (print $.Template.BasePath "/env-secret.yaml") . | sha256sum -}}
-{{- $replicaCount := (.Values.resources.deployment.replicas | default dict).default | default .Values.resources.deployment.replicaCount }}
+
+{{- $replicas := .Values.resources.deployment.replicas | default dict -}}
+{{- $minCount := $replicas.minCount | default 1 | int }}
+{{- $maxCount := $replicas.maxCount | default $minCount | int }}
+{{- $replicaCount := $replicas.default | default .Values.resources.deployment.replicaCount }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -14,7 +18,9 @@ metadata:
     app: {{ template "imgproxy.fullname" $ }}
   annotations: {{ .Values.resources.deployment.annotations | toYaml | nindent 4 }}
 spec:
+  {{- if (eq $minCount $maxCount) }}
   replicas: {{ $replicaCount | default 1 | int }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "imgproxy.fullname" $ }}


### PR DESCRIPTION
https://github.com/imgproxy/imgproxy-helm/issues/65

Deployment.spec.replicas should not exist if HorizontalPodAutoscaler is present otherwise it will cause conflict when using tools like anthos config sync. where deployment.spec.replicas will be constantly changed by both HorizontalPodAutoscaler
and config sync