### PR TITLE
Add ingressClassName field for ingress-health.yaml

### DIFF
--- a/imgproxy/templates/ingress-health.yaml
+++ b/imgproxy/templates/ingress-health.yaml
@@ -18,6 +18,9 @@ metadata:
     {{- toYaml .annotations | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .className }}
+  ingressClassName: {{ .className | quote }}
+  {{- end }}
   {{- if .tls }}
   tls:
     {{- range .tls }}


### PR DESCRIPTION
`ingressClassName` field has already added to main ingress resource, but not to ingress-health resource.