### PR TITLE
Add topologySpreadConstraints support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -329,7 +329,7 @@ Deployment specific options.
 |**resources.deployment.replicas.cpuUtilization**|The target percentage for the average CPU utilization by pods after which they should be scaled.|`80`|
 |**resources.deployment.resources**|Hash of resource limits for your pods|`{}`|
 |**resources.deployment.tolerations**|Tolerations for Kubernetes taints||
-|**resources.deployment.topologySpreadConstraints**| topologySpreadConstraints for distributing pods across zones|`[]`|
+|**resources.deployment.topologySpreadConstraints**|topologySpreadConstraints for distributing pods across zones|`[]`|
 |**resources.serviceAccount.annotations**|Annotations for the Kubernetes service account for imgproxy|``|
 |**resources.service.type**|Kubernetes service type for imgproxy|`ClusterIP`|
 |**resources.service.loadBalancerIP**|Load balancer ip for service type "LoadBalancer"|''|

--- a/Readme.md
+++ b/Readme.md
@@ -329,6 +329,7 @@ Deployment specific options.
 |**resources.deployment.replicas.cpuUtilization**|The target percentage for the average CPU utilization by pods after which they should be scaled.|`80`|
 |**resources.deployment.resources**|Hash of resource limits for your pods|`{}`|
 |**resources.deployment.tolerations**|Tolerations for Kubernetes taints||
+|**resources.deployment.topologySpreadConstraints**| topologySpreadConstraints for distributing pods across zones|`[]`|
 |**resources.serviceAccount.annotations**|Annotations for the Kubernetes service account for imgproxy|``|
 |**resources.service.type**|Kubernetes service type for imgproxy|`ClusterIP`|
 |**resources.service.loadBalancerIP**|Load balancer ip for service type "LoadBalancer"|''|

--- a/imgproxy/templates/deployment.yaml
+++ b/imgproxy/templates/deployment.yaml
@@ -70,6 +70,17 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "imgproxy.pvcName" . }}
       {{- end }}
+      {{- with .Values.resources.deployment.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- range $constraint := . }}
+        - {{ toYaml $constraint | nindent 10 | trim }}
+        {{- if not $constraint.labelSelector }}
+          labelSelector:
+            matchLabels:
+              app: {{ template "imgproxy.fullname" $ }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: "imgproxy"
           image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"

--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -102,6 +102,12 @@ resources:
     # Toleration for K8s taints
     tolerations: []
 
+    # topologySpreadConstraints https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+    topologySpreadConstraints: []
+    # - maxSkew: 1
+    #   topologyKey: topology.kubernetes.io/zone
+    #   whenUnsatisfiable: DoNotSchedule
+
     # Set kubernetes specific resource limits.
     # We claim `cpu: 1` for both limits and requests by default.
     resources: {}


### PR DESCRIPTION
Originally the helm chart doesn't support topologySpreadConstraints but they are useful when one runs a big imgproxy deployment and wants to make sure pods are distributed across some constraints evenly. Usually across AZs.