### PR TITLE
Use autoscaling/v2 when available

### DIFF
--- a/imgproxy/templates/_versions.tpl
+++ b/imgproxy/templates/_versions.tpl
@@ -36,7 +36,9 @@
     {{- $kubeVersion := $.Capabilities.KubeVersion.Version }}
     {{- $apiVersions := $.Capabilities.APIVersions }}
 
-    {{- if $kubeVersion | semverCompare ">=1.19.0-0" -}}
+    {{- if $apiVersions.Has "autoscaling/v2" -}}
+        {{- "autoscaling/v2" -}}
+    {{- else if $kubeVersion | semverCompare ">=1.19.0-0" -}}
         {{- "autoscaling/v2beta2" -}}
     {{- else if $kubeVersion | semverCompare ">=1.12.0-0" | and ($apiVersions.Has "autoscaling/v2beta2") -}}
         {{- "autoscaling/v2beta2" -}}


### PR DESCRIPTION
By using the autoscaling/v2 horizontal pod autoscaler version. Helm no longer complains about using a deprecated API version when using Kubernetes 1.23+.