### PR TITLE
Granular control over service account creation

### DIFF
--- a/imgproxy/templates/_helpers.tpl
+++ b/imgproxy/templates/_helpers.tpl
@@ -34,12 +34,15 @@ Template to generate secrets for a private Docker repository for K8s to use
 {{- end -}}
 
 {{/*
-Template to decide if the serviceAccount must be built
+Create the name of the service account to use
 */}}
-{{- define "serviceAccount.enabled" }}
-{{- $awsIamRoleDefined := and .Values.features.aws.enabled .Values.features.aws.iamRoleName -}}
-{{- $customAnnotations := .Values.resources.serviceAccount.annotations -}}
-{{- or $awsIamRoleDefined $customAnnotations -}}
+{{- define "imgproxy.serviceAccountName" -}}
+{{- $generatedName := (include "imgproxy.fullname" $ | printf "%s-service-account") -}}
+{{- if .Values.resources.serviceAccount.create }}
+{{- default $generatedName .Values.resources.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.resources.serviceAccount.name }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/imgproxy/templates/deployment.yaml
+++ b/imgproxy/templates/deployment.yaml
@@ -61,9 +61,7 @@ spec:
         {{- end }}
         {{- end }}
       {{- end }}
-      {{- if (include "serviceAccount.enabled" $) }}
-      serviceAccountName: "{{ template "imgproxy.fullname" $ }}-service-account"
-      {{- end }}
+      serviceAccountName: {{ include "imgproxy.serviceAccountName" . }}
       {{- if .Values.persistence.enabled }}
       volumes:
         - name: data

--- a/imgproxy/templates/service-account.yaml
+++ b/imgproxy/templates/service-account.yaml
@@ -1,22 +1,24 @@
-{{- if (include "serviceAccount.enabled" $) }}
+{{- if .Values.resources.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "imgproxy.fullname" $ }}-service-account
+  name: {{ template "imgproxy.serviceAccountName" $ }}
   labels:
     imgproxy: "true"
     {{- range $key, $val := ($.Values.resources.common.labels | default dict) }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+  {{- if or .Values.resources.serviceAccount.annotations .Values.features.aws.iamRoleName }}
   annotations:
     {{- with .Values.resources.serviceAccount }}
     {{- if .annotations }}
     {{- .annotations | toYaml | nindent 4 }}
     {{- end }}
     {{- end }}
+    {{- end }}
     {{- with .Values.features.aws }}
     {{- if and .enabled .iamRoleName }}
     {{ include "aws.iamRoleAnnotation" $ }}
     {{- end }}
-    {{- end }}
+  {{- end }}
 {{- end }}

--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -158,12 +158,18 @@ resources:
     # - 192.168.1.1/24
     # - 10.0.0.1/20
 
-  serviceAccount:
 
+  serviceAccount:
+    # Specifies whether a service account should be created
+    # Created anyway if features.aws.iamRoleName is set and name is unset
+    create: false
     # Add custom annotations to the Service Account
     # in addition to those we already provided for AWS IAM role
     # (see features.aws.iamRoleName and features.aws.accountId).
     annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
 
   ingress:
     enabled: false


### PR DESCRIPTION
Hi,
In my case I needed a way to somehow use the existing service account instead of creating a new one.

This PR introduce these of changes:

1. Service account creation should be explicitly enabled (via `serviceAccount.create`)
2. `serviceAccount.name` allows to explicitly provide name for a serviceAccount, either created or existing
3. [BREAKING] ServiceAccount is not created implicitly when `aws.iamRoleName` or `annotations` is present

Service account settings names in values.yaml are copied from default `helm create` template.
Are you open to these changes?
Though I think explicitness is better, we could found a way to preserve backward compatibility.