### PR TITLE
Add 'gcp' to allowed logging formats

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -319,7 +319,7 @@ The above command installs a specified version of imgproxy.
 
 |Value|Description|Default|
 |-----|-----------|-------|
-|**features.logging.format**|the log format. The following formats are supported: ['pretty', 'structured', 'json']|`pretty`|
+|**features.logging.format**|the log format. The following formats are supported: ['pretty', 'structured', 'json', 'gcp']|`pretty`|
 |**features.logging.level**|the log level. The following levels are supported error, warn, info and debug|`info`|
 |**features.logging.syslog.enabled**|when true, enables sending logs to syslog|`false`|
 |**features.logging.syslog.level**|maximum log level to send to syslog. Known levels are: crit, error, warning and info|`info`|

--- a/imgproxy/README.md
+++ b/imgproxy/README.md
@@ -356,7 +356,7 @@ The above command installs a specified version of imgproxy.
 
 |Value|Description|Default|
 |-----|-----------|-------|
-|**features.logging.format**|the log format. The following formats are supported: ['pretty', 'structured', 'json']|`pretty`|
+|**features.logging.format**|the log format. The following formats are supported: ['pretty', 'structured', 'json', 'gcp']|`pretty`|
 |**features.logging.level**|the log level. The following levels are supported error, warn, info and debug|`info`|
 |**features.logging.syslog.enabled**|when true, enables sending logs to syslog|`false`|
 |**features.logging.syslog.level**|maximum log level to send to syslog. Known levels are: crit, error, warning and info|`info`|

--- a/imgproxy/templates/env-secret.yaml
+++ b/imgproxy/templates/env-secret.yaml
@@ -537,8 +537,8 @@ data:
   {{- /* https://docs.imgproxy.net/#/configuration?id=log */}}
   {{- with .Values.features.logging }}
   {{- if .format }}
-  {{- if not (has .format (list "pretty" "structured" "json")) }}
-  {{- fail "The following formats are supported: `pretty`, `structured`, `json` at features.logging.format" }}
+  {{- if not (has .format (list "pretty" "structured" "json" "gcp")) }}
+  {{- fail "The following formats are supported: `pretty`, `structured`, `json`, `gcp` at features.logging.format" }}
   {{- end }}
   IMGPROXY_LOG_FORMAT: {{ .format | toString | b64enc | quote }} # {{ .format }}
   {{- end }}

--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -1085,10 +1085,11 @@ features:
   logging:
 
     # ENV['IMGPROXY_LOG_FORMAT']
-    # the log format. The following formats are supported: pretty, structured, json
+    # the log format. The following formats are supported: pretty, structured, json, gcp
     # - pretty: (default) colored human-readable format;
     # - structured: machine-readable format;
     # - json: JSON format;
+    # - gcp: Google Cloud Logging agent compliant format
     format: "pretty"
 
     # ENV['IMGPROXY_LOG_LEVEL']


### PR DESCRIPTION
As stated in the [documentation](https://docs.imgproxy.net/configuration?id=log) `gcp` is a valid option for the logging format.