### PR TITLE
Add extraEnvVars

### DIFF
--- a/imgproxy/templates/deployment.yaml
+++ b/imgproxy/templates/deployment.yaml
@@ -97,6 +97,10 @@ spec:
             - secretRef:
                 name: {{ $secretName }}
             {{- end }}
+          {{- with .Values.extraEnvVars }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources: {{ include "imgproxy.podResources" $ | nindent 12 }}
           {{- if .Values.persistence.enabled }}
           volumeMounts:


### PR DESCRIPTION
fix #48 

Support settings vars via `env`; this allow more flexibility over external Secret where key name is not a a choice (example: rook in bucket config), allow setting via configMap.