### PR TITLE
PodDisruptionBudget invalid

### DIFF
--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -221,7 +221,7 @@ resources:
 
   podDisruptionBudget:
     enabled: true
-    minAvailable: 0
+    minAvailable: 1
     maxUnavailable: 0
 
   pod:

--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -221,8 +221,8 @@ resources:
 
   podDisruptionBudget:
     enabled: true
-    minAvailable: 1
-    maxUnavailable: 0
+    minAvailable: 0
+    maxUnavailable: 1
 
   pod:
     annotations: {}


### PR DESCRIPTION
Although the PDB is enabled, neither minAvailable nor maxUnavailable have been set, which makes the PDB invalid and causes issues. By setting `maxUnavailable: 1` this should be solved.