### PR TITLE
Use mergeOverwrite to allow overriding limits.cpu with null

### DIFF
--- a/imgproxy/templates/_helpers.tpl
+++ b/imgproxy/templates/_helpers.tpl
@@ -101,7 +101,7 @@ https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.ht
 {{- end -}}
 
 {{- $custom := $.Values.resources.deployment.resources | default dict -}}
-{{- merge $custom $default | toYaml -}}
+{{- mergeOverwrite $default $custom | toYaml -}}
 {{- end -}}
 
 {{/* Combine ingress path from server.pathPrefix and ingress.pathSuffix */}}


### PR DESCRIPTION
Currently, the default CPU limit of "1" cannot be removed, because of the usage of merge here. Using mergeOverwrite will allow us to define "cpu: null" and wipe the CPU limit.

Note: It's worth a mention that in general, CPU limits are an anti-pattern and usually extremely wasteful in production!