### PR TITLE
Make Prometheus ServiceMonitor optional

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -426,7 +426,7 @@ Options to configure ServiceMonitor for Prometheus Operator.
 |-----|-----------|-------|
 |**features.prometheus.enabled**|Set IMGPROXY_PROMETHEUS_BIND environment variable to bind metrics to port 8081|`false`|
 |**features.prometheus.namespace**|Set IMGPROXY_PROMETHEUS_NAMESPACE environment variable to prepend prefix to the names of metrics|`""`|
-| **resources.serviceMonitor.enabled**|Use a ServiceMonitor to collect metrics|`true`|
+|**resources.serviceMonitor.enabled**|Use a ServiceMonitor to collect metrics|`true`|
 |**resources.serviceMonitor.honorLabels**|Chooses the metric's labels on collisions with target labels|`true`|
 |**resources.serviceMonitor.interval**|Interval at which metrics should be scraped (if it differs from default one)|`0`|
 |**resources.serviceMonitor.namespace**|Namespace with PrometheusOperator|`monitoring`|

--- a/Readme.md
+++ b/Readme.md
@@ -424,6 +424,7 @@ Options to configure ServiceMonitor for Prometheus Operator.
 |-----|-----------|-------|
 |**features.prometheus.enabled**|Set IMGPROXY_PROMETHEUS_BIND environment variable to bind metrics to port 8081|`false`|
 |**features.prometheus.namespace**|Set IMGPROXY_PROMETHEUS_NAMESPACE environment variable to prepend prefix to the names of metrics|`""`|
+| **resources.serviceMonitor.enabled**|use a ServiceMonitor to collect metrics|`true`|
 |**resources.serviceMonitor.honorLabels**|Chooses the metric's labels on collisions with target labels|`true`|
 |**resources.serviceMonitor.interval**|Interval at which metrics should be scraped (if it differs from default one)|`0`|
 |**resources.serviceMonitor.namespace**|Namespace with PrometheusOperator|`monitoring`|

--- a/Readme.md
+++ b/Readme.md
@@ -426,7 +426,7 @@ Options to configure ServiceMonitor for Prometheus Operator.
 |-----|-----------|-------|
 |**features.prometheus.enabled**|Set IMGPROXY_PROMETHEUS_BIND environment variable to bind metrics to port 8081|`false`|
 |**features.prometheus.namespace**|Set IMGPROXY_PROMETHEUS_NAMESPACE environment variable to prepend prefix to the names of metrics|`""`|
-| **resources.serviceMonitor.enabled**|use a ServiceMonitor to collect metrics|`true`|
+| **resources.serviceMonitor.enabled**|Use a ServiceMonitor to collect metrics|`true`|
 |**resources.serviceMonitor.honorLabels**|Chooses the metric's labels on collisions with target labels|`true`|
 |**resources.serviceMonitor.interval**|Interval at which metrics should be scraped (if it differs from default one)|`0`|
 |**resources.serviceMonitor.namespace**|Namespace with PrometheusOperator|`monitoring`|

--- a/imgproxy/README.md
+++ b/imgproxy/README.md
@@ -464,6 +464,7 @@ Options to configure ServiceMonitor for Prometheus Operator.
 |-----|-----------|-------|
 |**features.prometheus.enabled**|Set IMGPROXY_PROMETHEUS_BIND environment variable to bind metrics to port 8081|`false`|
 |**features.prometheus.namespace**|Set IMGPROXY_PROMETHEUS_NAMESPACE environment variable to prepend prefix to the names of metrics|`""`|
+|**resources.serviceMonitor.enabled**|Use a ServiceMonitor to collect metrics|`true`|
 |**resources.serviceMonitor.honorLabels**|Chooses the metric's labels on collisions with target labels|`true`|
 |**resources.serviceMonitor.interval**|Interval at which metrics should be scraped (if it differs from default one)|`0`|
 |**resources.serviceMonitor.namespace**|Namespace with PrometheusOperator|`monitoring`|

--- a/imgproxy/templates/service-monitor.yaml
+++ b/imgproxy/templates/service-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.features.prometheus.enabled }}
+{{- if and (.Values.features.prometheus.enabled) (.Values.resources.serviceMonitor.enabled) }}
 {{- with .Values.resources.serviceMonitor }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -210,6 +210,7 @@ resources:
     pathType: ImplementationSpecific
 
   serviceMonitor:
+    enabled: true
     honorLabels: true
     interval: 0
     namespace: ""


### PR DESCRIPTION
In our setup we don't use ServiceMonitors. Our auto scraper finds all pods and collects metrics from them if they have the correct annotations. For this setup we need to start the imgproxy metrics server and also expose the metrics endpoint in the Kubernetes service but don't want to start the ServiceMonitor. 

This pull pequest achieves exactly this: It enables ServiceMonitor by default (only when Prometheus is also enabled) to stay downward compatible for all existing deployments but it also allows to disable ServiceMonitor deployment.