### PR TITLE
Add LifecycleHook to image proxy chart

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -374,6 +374,7 @@ Deployment specific options.
 |**resources.pod.annotations**|Custom annotations for imgproxy pod|`{}`|
 |**resources.pod.labels**|Custom labels for imgproxy pods|`{}`|
 |**resources.deployment.readinessProbe**|Timeouts and counters for the readiness probe||
+|**resources.deployment.lifecylcle**|Lifecycle hook for the preStart or PreStop commands||
 |**resources.deployment.livenessProbe**|Timeouts and counters for the liveness probe||
 |**resources.deployment.minReadySeconds**|Minimum ready seconds for the statement set||
 |**resources.deployment.nodeSelector**|A node selector labels||

--- a/imgproxy/README.md
+++ b/imgproxy/README.md
@@ -411,6 +411,7 @@ Deployment specific options.
 |**resources.pod.annotations**|Custom annotations for imgproxy pod| `{}`        |
 |**resources.pod.labels**|Custom labels for imgproxy pods| `{}`        |
 |**resources.deployment.readinessProbe**|Timeouts and counters for the readiness probe||
+|**resources.deployment.lifecylcle**|Lifecycle hook for the preStart or PreStop commands||
 |**resources.deployment.livenessProbe**|Timeouts and counters for the liveness probe||
 |**resources.deployment.minReadySeconds**|Minimum ready seconds for the statement set||
 |**resources.deployment.nodeSelector**|A node selector labels||

--- a/imgproxy/templates/deployment.yaml
+++ b/imgproxy/templates/deployment.yaml
@@ -153,6 +153,7 @@ spec:
             successThreshold: {{ .successThreshold | default 1 }}
             failureThreshold: {{ .failureThreshold | default 5 }}
             {{- end }}
+          lifecycle: {{ toYaml .Values.resources.deployment.lifecycle | nindent 12 }}
       {{- if ($priorityClassName | and $priorityClassVersion) }}
       priorityClassName: {{ $priorityClassName | quote }}
       {{- end }}

--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -136,6 +136,17 @@ resources:
       successThreshold: 1
       failureThreshold: 5
 
+    # Lifecycle configuration
+    # Example:
+    #   postStart:
+    #     exec:
+    #       command: ["echo", "Hello from imgproxy"]
+    # Example:
+    #   preStop:
+    #     exec:
+    #       command: ["/bin/sleep", "30"]
+    lifecycle: {}
+
     # The minimum number of seconds for which a newly created pod should be ready
     # without any of its containers crashing, for it to be considered available.
     # It is set to 0 by default.


### PR DESCRIPTION
This pull request introduces an enhancement to the ImgProxy Chart by adding a LifecycleHook, specifically integrating Kubernetes' preStop and preStart lifecycle events.