### PR TITLE
 Add custom settings for podSecurityContext and containerSecurityContext instead of global securityContext

### DIFF
--- a/.github/templates/ISSUE.md
+++ b/.github/templates/ISSUE.md
@@ -3,5 +3,5 @@ title: Configuration of the imgproxy has been updated
 assignees: nepalez, dragonsmith
 labels: enhancement
 ---
-@{{ github.event.client_payload.actor }} has just updated the [Configuration](https://docs.imgproxy.net/configuration) part of the documentation.
-Please, check [the difference]({{ github.event.client_payload.link }}) and make the necessary changes in the Helm chart.
+@{{ payload.actor }} has just updated the [Configuration](https://docs.imgproxy.net/configuration/options) part of the documentation.
+Please, check [the difference]({{ payload.link }}) and make the necessary changes in the Helm chart.

--- a/.github/templates/ISSUE.md
+++ b/.github/templates/ISSUE.md
@@ -3,5 +3,5 @@ title: Configuration of the imgproxy has been updated
 assignees: nepalez, dragonsmith
 labels: enhancement
 ---
-@{{ payload.actor }} has just updated the [Configuration](https://docs.imgproxy.net/configuration/options) part of the documentation.
-Please, check [the difference]({{ payload.link }}) and make the necessary changes in the Helm chart.
+@{{ payload.client_payload.actor }} has just updated the [Configuration](https://docs.imgproxy.net/configuration/options) part of the documentation.
+Please, check [the difference]({{ payload.client_payload.link }}) and make the necessary changes in the Helm chart.

--- a/.github/workflows/imgproxy-config-updated.yml
+++ b/.github/workflows/imgproxy-config-updated.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   create-issue:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4

--- a/.github/workflows/imgproxy-config-updated.yml
+++ b/.github/workflows/imgproxy-config-updated.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
-        with:
-          path: imgproxy-helm/
 
       - name: Create an issue
         uses: JasonEtco/create-an-issue@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   release-helm-chart:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.1 (2024-02-27)
+
+* Add custom settings for `podSecurityContext` and `containerSecurityContext` instead of global `securityContext`
+
 ## 0.9.0 (2023-10-09)
 
 * Support imgproxy v3.20.0

--- a/Readme.md
+++ b/Readme.md
@@ -392,7 +392,8 @@ Deployment specific options.
 |**resources.deployment.replicas.stabilizationInterval**|The number of seconds for which past recommendations should be considered while scaling up or scaling down (0 - 3600) to prevent flapping.|`300`|
 |**resources.deployment.replicas.cpuUtilization**|The target percentage for the average CPU utilization by pods after which they should be scaled.|`80`|
 |**resources.deployment.resources**|Hash of resource limits for your pods|`{}`|
-|**resources.deployment.securityContext**|Hash of security context settings for your pods|`{}`|
+|**resources.deployment.podSecurityContext**|Hash of security context settings for your pods|`{}`|
+|**resources.deployment.containerSecurityContext**|Hash of security context settings for your containers|`{}`|  
 |**resources.deployment.terminationGracePeriodSeconds**|A custom amount of time to terminate the app|`30`|
 |**resources.deployment.tolerations**|Tolerations for Kubernetes taints||
 |**resources.deployment.topologySpreadConstraints**|topologySpreadConstraints for distributing pods across zones|`[]`|

--- a/imgproxy/README.md
+++ b/imgproxy/README.md
@@ -429,7 +429,8 @@ Deployment specific options.
 |**resources.deployment.replicas.stabilizationInterval**|The number of seconds for which past recommendations should be considered while scaling up or scaling down (0 - 3600) to prevent flapping.| `300`       |
 |**resources.deployment.replicas.cpuUtilization**|The target percentage for the average CPU utilization by pods after which they should be scaled.| `80`        |
 |**resources.deployment.resources**|Hash of resource limits for your pods| `{}`        |
-|**resources.deployment.securityContext**|Hash of security context settings for your pods|`{}`|
+|**resources.deployment.podSecurityContext**|Hash of security context settings for your pods|`{}`|
+|**resources.deployment.containerSecurityContext**|Hash of security context settings for your containers|`{}`|  
 |**resources.deployment.terminationGracePeriodSeconds**|A custom amount of time to terminate the app|`30`|
 |**resources.deployment.tolerations**|Tolerations for Kubernetes taints||
 |**resources.deployment.topologySpreadConstraints**|Topology spread constraints for distributing pods across zones|`[]`|

--- a/imgproxy/templates/deployment.yaml
+++ b/imgproxy/templates/deployment.yaml
@@ -64,8 +64,8 @@ spec:
         {{- end }}
         {{- end }}
       {{- end }}
-      {{- if $.Values.resources.deployment.securityContext }}
-      securityContext: {{ $.Values.resources.deployment.securityContext | toYaml | nindent 8 }}
+      {{- if $.Values.resources.deployment.podSecurityContext }}
+      securityContext: {{ $.Values.resources.deployment.podSecurityContext | toYaml | nindent 8 }}
       {{- end }}
       {{- if $.Values.resources.serviceAccount.existingName }}
       serviceAccountName: {{ $.Values.resources.serviceAccount.existingName | quote }}
@@ -95,6 +95,9 @@ spec:
       containers:
         - name: "imgproxy"
           image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
+          {{- if $.Values.resources.deployment.containerSecurityContext }}
+          securityContext: {{ $.Values.resources.deployment.containerSecurityContext | toYaml | nindent 12 }}
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - secretRef:

--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -143,10 +143,21 @@ resources:
 
     # A security context defines privilege and access control settings for the deployment.
     # Check available settings in the documentation by link:
-    # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-    securityContext: {}
-      # allowPrivilegeEscalation: false
+    # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+    podSecurityContext: {}
+      # fsGroup: 999
+
+    # A security context defines privilege and access control settings for containers.
+    # Check available settings in the documentation by link:
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+    containerSecurityContext: {}
+      # runAsUser: 999
       # runAsNonRoot: true
+      # allowPrivilegeEscalation: false
+      # capabilities:
+      #   drop: ["ALL"]
+      # seccompProfile:
+      #   type: "RuntimeDefault"
 
     # A custom amount of time (in seconds) to terminate the app after pre-stop hook is called,
     # or a TERM signal is received.


### PR DESCRIPTION
## Summary
This pull request introduces custom settings for podSecurityContext and containerSecurityContext to ensure compatibility with restricted Pod Security Admission levels. 
By adjusting the security context configurationsat the pod and the container level, the application will adhere to the stricter security policies enforced within the Kubernetes cluster.

## Context
Currently, the application is unable to run in Kubernetes environments with restricted Pod Security Admission levels due to insufficient security context configurations. This pull request addresses this issue by implementing the necessary adjustments to the security settings, thereby enabling the application to be deployed and run securely in such environments.

When deploying imgproxy in a namespace with pod-security.kubernetes.io/enforce: baseline and we set the values like this :

`   
securityContext:
      runAsNonRoot: true
      allowPrivilegeEscalation: false
      capabilities:
        drop:
          - ALL
      seccompProfile:
        type: RuntimeDefault
`

We get this warning : 
  
`Warning: would violate PodSecurity "restricted:v1.27": allowPrivilegeEscalation != false (container "imgproxy" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "imgproxy" must set securityContext.capabilities.drop=["ALL"])`

## Changes Made
- Added podSecurityContext and containerSecurityContext parameters in the deployment YAML file.
- Updated values file with the new parameters.
- Updated Changelog and readme

## Testing
- Manually tested the application deployment using minikube with restricted Pod Security Admission level enabled.

## Checklist
- [x] Added podSecurityContext and containerSecurityContext parameters.
- [x]  Update changelog and documentation
- [x] Tested the deployment in a minikube environment with restricted Pod Security Admission level.
