### PR TITLE
Set default resources.ingress.hosts to `[~]`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -203,7 +203,7 @@ Options for downloading the imgproxy image
 |**resources.ingress.annotations**|Additional annotations for the ingress resource||
 |**resources.ingress.enabled**|When true, enables ingress resource for imgproxy|`false`|
 |**resources.ingress.health.whitelist**|Comma separated string of CIDR addresses that are allowed to access `/health` url of imgproxy||
-|**resources.ingress.hosts**|Hostnames for the ingress resource to use|`["example.com"]`|
+|**resources.ingress.hosts**|Hostnames for the ingress resource to use|`[~]`|
 |**resources.ingress.pathSuffix**|Suffix to be added to path prefix, for example wildcard '*' for AWS balancer||
 |**resources.ingress.tls**|TLS config array||
 |**resources.ingress.tls[].hosts**|Hostnames this tls secret is used for|`["example.com"]`|

--- a/Readme.md
+++ b/Readme.md
@@ -208,6 +208,7 @@ Options for downloading the imgproxy image
 |**resources.ingress.tls**|TLS config array||
 |**resources.ingress.tls[].hosts**|Hostnames this tls secret is used for|`["example.com"]`|
 |**resources.ingress.tls[].secretName**|Name of the k8s Secret resource which stores crt & key for the ingress resource||
+|**resources.ingress.className**|ingressClassName to use||
 
 See `values.yaml` for some more Kubernetes-specific configuration options.
 

--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -15,7 +15,6 @@ image:
 
 # Configure K8s resources
 resources:
-
   # Settings applied to every single resource of the chart.
   common:
     labels: {}
@@ -23,7 +22,6 @@ resources:
   deployment:
     # https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
     priority:
-
       # The name of the priority class to be used in both pod.PriorityClassName
       # and the PriorityClass (when a level is above 0).
       # When a level is not set, or set to 0 (default), then the definition
@@ -49,7 +47,6 @@ resources:
     #
     # This part can be skipped, in that case 1 replica will be used.
     replicas:
-
       # The default number of replicas to start from (default 1)
       default: 1
 
@@ -154,7 +151,8 @@ resources:
     # A security context defines privilege and access control settings for the deployment.
     # Check available settings in the documentation by link:
     # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-    securityContext: {}
+    securityContext:
+      {}
       # allowPrivilegeEscalation: false
       # runAsNonRoot: true
 
@@ -219,7 +217,7 @@ resources:
     annotations: {}
     #   kubernetes.io/ingress.class: nginx
     #   kubernetes.io/tls-acme: "true"
-    hosts: []
+    hosts: [~]
     #   - example.com
     #   - www.example.com
     tls: []


### PR DESCRIPTION
Currently, it's not possible to enable ingress without setting `resources.ingress.hosts`. But it's not always necessary to specify a host in the ingress rules. For example, when you use a separate AWS ALB as ingress.