### PR TITLE
Make service.bind port changeable, remain with the former default 80,…

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -428,6 +428,7 @@ Deployment specific options.
 |**resources.service.loadBalancerSourceRanges**| Load balancer source ranges for service type "LoadBalancer"|`[]|
 |**resources.service.externalTrafficPolicy**| Enable client source IP preservation |`Cluster`|
 |**resources.service.nodePort**|Set the initial value when Kubernetes type is NodePort|``|
+|**resources.service.bind**|Set the bind port of the service (in docker it was port 8080, we use in k8s direct http port as default|`80`|
 
 ### Ingress configuration
 

--- a/imgproxy/README.md
+++ b/imgproxy/README.md
@@ -442,6 +442,7 @@ Deployment specific options.
 |**resources.service.loadBalancerSourceRanges**| Load balancer source ranges for service type "LoadBalancer"| `[]         |
 |**resources.service.externalTrafficPolicy**| Enable client source IP preservation | `Cluster`   |
 |**resources.service.nodePort**|Set the initial value when Kubernetes type is NodePort|``|
+|**resources.service.bind**|Set the bind port of the service (in docker it was port 8080, we use in k8s direct http port as default|`80`|
 
 ### Ingress configuration
 

--- a/imgproxy/templates/service.yaml
+++ b/imgproxy/templates/service.yaml
@@ -34,7 +34,7 @@ spec:
     app: "{{ template "imgproxy.fullname" $ }}"
   ports:
     - name: http
-      port: 80
+      port: {{ .bind | default 80 }}
       protocol: TCP
       targetPort: 8080
       {{- if eq .type "NodePort" }}

--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -192,6 +192,7 @@ resources:
     externalTrafficPolicy: Cluster
     loadBalancerSourceRanges:
     nodePort:
+    bind: 80
     # - 192.168.1.1/24
     # - 10.0.0.1/20
 


### PR DESCRIPTION
… issue #158, refs #158

The service bind port is now configurable.

In Docker the default exposal port was 8080, but since we use in k8s/helm environment service port 80, i let remain it as default 80.