### PR TITLE
Remove duplicate configuration key

### DIFF
--- a/imgproxy/README.md
+++ b/imgproxy/README.md
@@ -394,7 +394,6 @@ The above command installs a specified version of imgproxy.
 |**features.miscellaneous.enforceThumbnail**|When `true` and the source image has an embedded thumbnail, imgproxy will always use the embedded thumbnail instead of the main image.|`false`|
 |**features.miscellaneous.returnAttachment**|when true, response header Content-Disposition will include attachment.|`false`|
 |**features.miscellaneous.svgFixUnsupported**|when `true`, imgproxy will try to replace SVG features unsupported by librsvg to minimize SVG rendering error. This config only takes effect on SVG rasterization.|`false`|
-|**features.miscellaneous.stripMetadata**|whether to strip all metadata (EXIF, IPTC, etc.) from JPEG and WebP output images|`true`|
 
 ### k8s deployment
 

--- a/imgproxy/README.md
+++ b/imgproxy/README.md
@@ -171,7 +171,7 @@ The above command installs a specified version of imgproxy.
 |**features.autoquality.formatMin**|Minimal quality imgproxy can use per format, comma divided.|`avif=40`|
 |**features.autoquality.formatMax**|Maximal quality imgproxy can use per format, comma divided.|`avif=50`|
 |**features.autoquality.allowedError**|Allowed quality target error. Applicable only to `dssim` and `ml` methods.|`0.001`|
-|**features.autoquality.maxResolution**|When value is greater then zero and the result resolution exceeds the value, autoquality won’t be used.|`0`|
+|**features.autoquality.maxResolution**|When value is greater than zero and the result resolution exceeds the value, autoquality won’t be used.|`0`|
 |**features.autoquality.jpegNet**|Neural networks path for JPEG (applied to 'ml' method only).||
 |**features.autoquality.webpNet**|Neural networks path for WEBP (applied to 'ml' method only).||
 |**features.autoquality.avifNet**|Neural networks path for AVIF (applied to 'ml' method only).||


### PR DESCRIPTION
`features.miscellaneous.stripMetadata` was listed twice.