### PR TITLE
chore: bump image to v3.24.1

### DIFF
--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -2,7 +2,7 @@
 # Docker image repository, tag, policy and secrets for Kubernetes to pull it.
 image:
   repo: darthsim/imgproxy
-  tag: v3.20.0
+  tag: v3.24.1
   pullPolicy: IfNotPresent
   # create new image-pull-secret if enabled: true
   pullSecrets:


### PR DESCRIPTION
This PR bumps the default image version from v3.20.0 to v3.24.1.
It would be nice if this change could release a new version of the chart, so that a more current version of imgproxy would be the default of the helm-chart.