### PR TITLE
feat: add extraVolumes + extraVolumeMount

### DIFF
--- a/imgproxy/templates/deployment.yaml
+++ b/imgproxy/templates/deployment.yaml
@@ -73,8 +73,13 @@ spec:
       {{- else if (include "serviceAccount.enabled" $) }}
       serviceAccountName: "{{ template "imgproxy.fullname" $ }}-service-account"
       {{- end }}
-      {{- if .Values.persistence.enabled }}
       volumes:
+        - name: empty-dir
+          emptyDir: {}
+      {{- if .Values.extraVolumes }}
+        {{ .Values.extraVolumes | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.persistence.enabled }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "imgproxy.pvcName" . }}
@@ -105,8 +110,14 @@ spec:
                 name: {{ $secretName }}
             {{- end }}
           resources: {{ include "imgproxy.podResources" $ | nindent 12 }}
-          {{- if .Values.persistence.enabled }}
           volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+          {{- if .Values.extraVolumeMounts}}
+            {{ .Values.extraVolumeMounts | toYaml | nindent 12}}
+          {{- end}}
+          {{- if .Values.persistence.enabled }}
             - name: data
               mountPath: {{ .Values.persistence.mountPath }}
               {{- if .Values.persistence.subPath }}

--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -1283,3 +1283,10 @@ features:
   # custom:
   #   IMGPROXY_FOO: bar
   custom: {}
+
+# extraVolumes Optionally specify extra list of additional volumes for imgproxy; provisioning pod
+
+extraVolumes: []
+
+# extraVolumeMounts Optionally specify extra list of additional volumeMounts for imgproxy; provisioning container
+extraVolumeMounts: []


### PR DESCRIPTION
Add extra Volumes and extra volumeMounts to the deployment

Example:
```
extraVolumeMounts:
  - name: selfsigned-volume
    mountPath: /usr/local/share/ca-certificates/selsigned.crt
    subPath: tls.crt

extraVolumes:
  - name: selfsigned-volume
    secret:
      secretName: selfsigned-ca
```