### PR TITLE
feat: Add support for using existing PriorityClass when level=0

### DIFF
--- a/imgproxy/templates/_helpers.tpl
+++ b/imgproxy/templates/_helpers.tpl
@@ -71,7 +71,7 @@ https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.ht
        {{- if (include "imgproxy.versions.priorityClass" $) }}
             {{- $defaultName := (include "imgproxy.fullname" $ | printf "%s-priority") }}
             {{- $name := default $defaultName .name }}
-            {{- if (has $name $systemNames | or .level) }}
+            {{- if (has $name $systemNames | or .level | or .name) }}
                 {{- $name }}
             {{- end }}
        {{- end }}
@@ -83,7 +83,7 @@ https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.ht
     {{- with .Values.resources.deployment.priority }}
         {{- $systemNames := list "set-cluster-critical" "set-node-critical" }}
         {{- $name := include "imgproxy.resources.priorityClassName" $ }}
-        {{- if ($name | and (not (has $name $systemNames))) }}
+        {{- if ($name | and (not (has $name $systemNames)) | and .level) }}
             {{- $name }}
         {{- end }}
     {{- end }}

--- a/imgproxy/values.yaml
+++ b/imgproxy/values.yaml
@@ -26,14 +26,19 @@ resources:
 
       # The name of the priority class to be used in both pod.PriorityClassName
       # and the PriorityClass (when a level is above 0).
-      # When a level is not set, or set to 0 (default), then the definition
-      # of the corresponding PriorityClass is up to the user.
+      # 
+      # Usage scenarios:
+      # 1. level > 0: A new PriorityClass will be created with this name and assigned to pods
+      # 2. level = 0 + name provided: Use an existing PriorityClass with this name (no new PriorityClass created)
+      # 3. level = 0 + no name: No PriorityClass will be used
+      # 
       # You can use system names like `set-cluster-critical` and `set-node-critical` as well,
       # in this case the class won't be created and level is ignored.
       name: ~
 
       # If the level is above 0, then a correspoding PriorityClass will be created
-      # and assigned to the pod by the `PriorityClassName`
+      # and assigned to the pod by the `PriorityClassName`.
+      # If level is 0 but name is provided, an existing PriorityClass with that name will be used.
       level: 0
 
       # This setting is supported in K8s v1.19+, otherwise it will be ignored


### PR DESCRIPTION
## Description
This PR adds support for using existing PriorityClass resources in the cluster when `level=0` and a `name` is provided. Previously, users could only create new PriorityClass resources or not use any priority at all.

## Changes
- Modified `imgproxy.resources.priorityClassName` helper to return the name when `level=0` and a name is provided
- Updated `imgproxy.resources.explicitPriorityClassName` helper to only create PriorityClass resources when `level > 0`
- Enhanced documentation in `values.yaml` to clearly explain the three usage scenarios

## Usage Scenarios
1. **`level > 0`**: Creates a new PriorityClass with the specified name and assigns it to pods
2. **`level = 0` + `name` provided**: Uses an existing PriorityClass with the specified name (no new PriorityClass created)
3. **`level = 0` + no `name`**: No PriorityClass is used

## Example
```yaml
resources:
  deployment:
    priority:
      name: "my-existing-priority-class"
      level: 0
```

## Testing
- Verified that existing PriorityClass is used when `level=0` and `name` is provided
- Confirmed that new PriorityClass is still created when `level > 0`
- Ensured no PriorityClass is used when both `level=0` and no `name` is provided
- All existing functionality remains backward compatible

## Backward Compatibility
This change is fully backward compatible. All existing configurations will continue to work as before.